### PR TITLE
feat: 將 Web API 輸出 Markdown 中的圖片路徑簡化為僅保留檔名（移除資料夾路徑）

### DIFF
--- a/web_api/app.py
+++ b/web_api/app.py
@@ -122,7 +122,7 @@ async def pdf_parse_main(
 
         # Save results in text and md format
         content_list = pipe.pipe_mk_uni_format(image_path_parent, drop_mode="none")
-        md_content = pipe.pipe_mk_markdown(image_path_parent, drop_mode="none")
+        md_content = pipe.pipe_mk_markdown(img_parent_path="/", drop_mode="none")
 
         if is_json_md_dump:
             json_md_dump(pipe, md_writer, pdf_name, content_list, md_content)


### PR DESCRIPTION
修改前:
![image](https://github.com/user-attachments/assets/ed944320-c535-4217-9d15-5a69f0a2f969)

修改後:
![image](https://github.com/user-attachments/assets/4706933d-7e36-4f4f-840d-f8d26069298c)
