### PR TITLE
feat: 使用 dumb-init 作為容器 entrypoint

### DIFF
--- a/web_api/Dockerfile
+++ b/web_api/Dockerfile
@@ -76,6 +76,7 @@ RUN sed -i "s/formula: True/formula: False/g" /opt/mineru_venv/lib/python3.10/si
 
 # Copy the configuration file template and set up the model directory
 COPY magic-pdf.json /root/magic-pdf.json
+COPY docker-entrypoint.sh /root/docker-entrypoint.sh
 ADD app.py /root/app.py
 
 WORKDIR /root
@@ -88,10 +89,10 @@ WORKDIR /root
 
 # Set the entry point to activate the virtual environment and run the command line tool
 # ENTRYPOINT ["/bin/bash", "-c", "source /opt/mineru_venv/bin/activate && exec \"$@\" && python3 app.py", "--"]
-
+# dumb-init
++RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && chmod +x /usr/local/bin/dumb-init && ln -s /usr/local/bin/dumb-init /usr/bin/dumb-init
 
 # Expose the port that FastAPI will run on
 EXPOSE 8000
 
-# Command to run FastAPI using Uvicorn, pointing to app.py and binding to 0.0.0.0:8000
-CMD ["/bin/bash", "-c", "source /opt/mineru_venv/bin/activate && uvicorn app:app --host 0.0.0.0 --port 8000"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "bash", "docker-entrypoint.sh"]

--- a/web_api/docker-entrypoint.sh
+++ b/web_api/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Command to run FastAPI using Uvicorn, pointing to app.py and binding to 0.0.0.0:8000
+set -e
+source /opt/mineru_venv/bin/activate
+exec uvicorn app:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
整合 dumb-init 作為容器的 entrypoint，並支援在容器啟動階段動態修改設定檔（例如 magic-pdf.json），再啟動主應用服務。此設計允許透過 sed 指令於啟動前修改配置，例如根據環境變數動態調整 device-mode（如 CPU 或 CUDA 模式），以提升部署靈活性與維護彈性。