### PR TITLE
feat: ocr API 支援 `slice` 參數，預設為啟用。

### DIFF
--- a/web_api/Dockerfile
+++ b/web_api/Dockerfile
@@ -35,13 +35,19 @@ RUN dpkg-reconfigure -f noninteractive tzdata
 # Create a virtual environment for MinerU
 RUN python3 -m venv /opt/mineru_venv
 
+# 注意：因為paddleocr 2.8 之後才支援 `slice` 且3.x 尚不支援 `slice`，因此目前安裝最新版本的2.x(即2.10.0)
+# Ref: 
+#   - slice 功能 PR: https://github.com/PaddlePaddle/PaddleOCR/pull/12152/files
+#   - 3.x 版本後，OCR入口變了，原本的很多參數都不能用，包含slice
+#       - 新入口：https://github.com/PaddlePaddle/PaddleOCR/blob/4a8aa277f331b22d2eeb86f60adc766149c05c1d/paddleocr/_pipelines/ocr.py#L194
+#       - 舊入口：https://github.com/PaddlePaddle/PaddleOCR/blob/v2.8.0/paddleocr.py#L674
 RUN /bin/bash -c "source /opt/mineru_venv/bin/activate && \
     pip install --upgrade pip && \
     pip install fastapi \
     uvicorn \
     python-multipart \
     ultralytics==8.3.39 \
-    paddleocr==2.7.3 \
+    paddleocr==2.10.0" \
     paddlepaddle==2.5.2 \
     struct-eqtable==0.1.0 \
     unimernet==0.1.6 \

--- a/web_api/app.py
+++ b/web_api/app.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
 import uvicorn
-from fastapi import Body, FastAPI, File, HTTPException, Query, UploadFile
+from fastapi import Body, FastAPI, File, HTTPException, Query, UploadFile, Form
 from fastapi.responses import JSONResponse
 from loguru import logger
 from paddleocr import PaddleOCR
@@ -21,8 +21,27 @@ from magic_pdf.rw.DiskReaderWriter import DiskReaderWriter
 
 
 class CustomPaddleOCR(PaddleOCR):
-    def image_ocr(self, image_bytes: bytes) -> List[str]:
-        results = self.ocr(image_bytes, cls=True)
+    def image_ocr(
+        self,
+        image_bytes: bytes,
+        use_slice: bool,
+        horizontal_stride: int,
+        vertical_stride: int,
+        merge_x_thres: int,
+        merge_y_thres: int,
+    ) -> List[str]:
+
+        kwargs = {"cls": True}
+        if use_slice:
+            kwargs["slice"] = {
+                "horizontal_stride": horizontal_stride,
+                "vertical_stride": vertical_stride,
+                "merge_x_thres": merge_x_thres,
+                "merge_y_thres": merge_y_thres,
+            }
+
+        results = self.ocr(image_bytes, **kwargs)
+
         if results[0] is None:
             return []
         output = list()
@@ -79,10 +98,32 @@ def root():
 
 
 @app.post("/ocr", tags=["projects"], summary="Do Image OCR")
-async def ocr_endpoint(image_file: UploadFile = File(...)):
-    """接收上傳圖片並進行文字辨識 (OCR)
+async def ocr_endpoint(
+    image_file: UploadFile = File(...),
+    use_slice: bool = Form(
+        True,
+        description="是否要進行切片操作，參考：https://github.com/PaddlePaddle/PaddleOCR/blob/v3.1.0/docs/version2.x/ppocr/blog/slice.md",
+    ),
+    horizontal_stride: int = Form(
+        300, description="切片y軸步幅，當use_slice=true時生效"
+    ),
+    vertical_stride: int = Form(500, description="切片x軸步幅，當use_slice=true時生效"),
+    merge_x_thres: int = Form(
+        50, description="切片x軸合併門檻，當use_slice=true時生效"
+    ),
+    merge_y_thres: int = Form(
+        35, description="切片y軸合併門檻，當use_slice=true時生效"
+    ),
+):
+    """接收上傳圖片並進行文字辨識 (OCR)，可選擇是否使用切片(slice)模式以提升大圖的辨識效率。
+
     Args:
         image_file (UploadFile): 上傳的圖片檔案。
+        use_slice (bool): 是否啟用圖片切片模式。若為True，會將大圖切成多片分別辨識，再合併結果。預設為True。
+        horizontal_stride (int): 切片時水平方向（y軸）的步幅，影響切片重疊與數量，use_slice=True時生效。預設300。
+        vertical_stride (int): 切片時垂直方向（x軸）的步幅，影響切片重疊與數量，use_slice=True時生效。預設500。
+        merge_x_thres (int): 切片結果合併時，x軸方向合併文字區塊的閾值，use_slice=True時生效。預設50。
+        merge_y_thres (int): 切片結果合併時，y軸方向合併文字區塊的閾值，use_slice=True時生效。預設35。
 
     Returns:
         JSONResponse: 若成功則回傳辨識結果（List[str]）；若失敗則回傳錯誤訊息與 HTTP 500。
@@ -106,7 +147,14 @@ async def ocr_endpoint(image_file: UploadFile = File(...)):
     try:
         # 將 UploadFile 的內容讀取為 bytes
         image_bytes = await image_file.read()
-        result = ocr_model.image_ocr(image_bytes)
+        result = ocr_model.image_ocr(
+            image_bytes,
+            use_slice,
+            horizontal_stride,
+            vertical_stride,
+            merge_x_thres,
+            merge_y_thres,
+        )
         return JSONResponse(
             content={"status": "success", "result": result}, status_code=200
         )


### PR DESCRIPTION
## Motivation

考量OCR針對大圖的辨識表現不佳，因此在ocr API加上slice參數，將圖片切小分開預測再合併.

## Modification

- paddleocr 升級至 2.10.0 ，該版本支援 `slice` 參數.
- ocr API加上slice參數，將圖片切小分開預測再合併.

